### PR TITLE
Prune cities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 secrets/google_sa.json
 secrets/twitter_keys.json
 .idea
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "prettier.trailingComma": "es5",
+  "prettier.arrowParens": "always"
+}

--- a/backend/city_tweet_mood.js
+++ b/backend/city_tweet_mood.js
@@ -11,7 +11,7 @@ const twitter_client = new Twitter({
   consumer_key: twitter_secrets.TWITTER_API,
   consumer_secret: twitter_secrets.TWITTER_SECRET,
   access_token_key: twitter_secrets.TWITTER_ACCESS_TOKEN,
-  access_token_secret: twitter_secrets.TWITTER_ACCESS_SECRET
+  access_token_secret: twitter_secrets.TWITTER_ACCESS_SECRET,
 });
 const NUM_OF_TWEETS = 100;
 
@@ -28,15 +28,15 @@ async function get_city_tweets(coordinates, radius) {
     geocode: coordinates + "," + radius,
     lang: "en",
     count: NUM_OF_TWEETS,
-    tweet_mode: "extended"
+    tweet_mode: "extended",
   };
   let tweets = await twitter_client.get("search/tweets", search_params);
-  return Promise.resolve(tweets.statuses.map(tweet => tweet.full_text));
+  return Promise.resolve(tweets.statuses.map((tweet) => tweet.full_text));
 }
 
 async function sentiment_helper(doc) {
   let [result] = await google_client.analyzeSentiment({
-    document: doc
+    document: doc,
   });
   return Promise.resolve(result.documentSentiment);
 }
@@ -49,13 +49,13 @@ async function sentiment_helper(doc) {
  */
 function get_sentiment(text_arr) {
   return Promise.all(
-    text_arr.map(async text => {
+    text_arr.map(async (text) => {
       return {
         text: text,
         sentiment: await sentiment_helper({
           content: text,
-          type: "PLAIN_TEXT"
-        })
+          type: "PLAIN_TEXT",
+        }),
       };
     })
   );
@@ -73,5 +73,5 @@ async function get_tweets_and_sentiment(coordinates, radius) {
 }
 
 module.exports = {
-  get_tweets_and_sentiment: get_tweets_and_sentiment
+  get_tweets_and_sentiment: get_tweets_and_sentiment,
 };

--- a/public/assets/pruned_cities.json
+++ b/public/assets/pruned_cities.json
@@ -459,60 +459,6 @@
     "state": "Vermont"
   },
   {
-    "city": "New York",
-    "growth_from_2000_to_2013": "4.8%",
-    "latitude": 40.7127837,
-    "longitude": -74.0059413,
-    "population": "8405837",
-    "rank": "1",
-    "state": "New York"
-  },
-  {
-    "city": "Los Angeles",
-    "growth_from_2000_to_2013": "4.8%",
-    "latitude": 34.0522342,
-    "longitude": -118.2436849,
-    "population": "3884307",
-    "rank": "2",
-    "state": "California"
-  },
-  {
-    "city": "Chicago",
-    "growth_from_2000_to_2013": "-6.1%",
-    "latitude": 41.8781136,
-    "longitude": -87.6297982,
-    "population": "2718782",
-    "rank": "3",
-    "state": "Illinois"
-  },
-  {
-    "city": "Houston",
-    "growth_from_2000_to_2013": "11.0%",
-    "latitude": 29.7604267,
-    "longitude": -95.3698028,
-    "population": "2195914",
-    "rank": "4",
-    "state": "Texas"
-  },
-  {
-    "city": "Philadelphia",
-    "growth_from_2000_to_2013": "2.6%",
-    "latitude": 39.9525839,
-    "longitude": -75.1652215,
-    "population": "1553165",
-    "rank": "5",
-    "state": "Pennsylvania"
-  },
-  {
-    "city": "Phoenix",
-    "growth_from_2000_to_2013": "14.0%",
-    "latitude": 33.4483771,
-    "longitude": -112.0740373,
-    "population": "1513367",
-    "rank": "6",
-    "state": "Arizona"
-  },
-  {
     "city": "San Antonio",
     "growth_from_2000_to_2013": "21.0%",
     "latitude": 29.4241219,
@@ -558,24 +504,6 @@
     "state": "Texas"
   },
   {
-    "city": "Indianapolis",
-    "growth_from_2000_to_2013": "7.8%",
-    "latitude": 39.768403,
-    "longitude": -86.158068,
-    "population": "843393",
-    "rank": "12",
-    "state": "Indiana"
-  },
-  {
-    "city": "Jacksonville",
-    "growth_from_2000_to_2013": "14.3%",
-    "latitude": 30.3321838,
-    "longitude": -81.65565099999999,
-    "population": "842583",
-    "rank": "13",
-    "state": "Florida"
-  },
-  {
     "city": "San Francisco",
     "growth_from_2000_to_2013": "7.7%",
     "latitude": 37.7749295,
@@ -583,24 +511,6 @@
     "population": "837442",
     "rank": "14",
     "state": "California"
-  },
-  {
-    "city": "Columbus",
-    "growth_from_2000_to_2013": "14.8%",
-    "latitude": 39.9611755,
-    "longitude": -82.99879419999999,
-    "population": "822553",
-    "rank": "15",
-    "state": "Ohio"
-  },
-  {
-    "city": "Charlotte",
-    "growth_from_2000_to_2013": "39.1%",
-    "latitude": 35.2270869,
-    "longitude": -80.8431267,
-    "population": "792862",
-    "rank": "16",
-    "state": "North Carolina"
   },
   {
     "city": "Fort Worth",
@@ -612,15 +522,6 @@
     "state": "Texas"
   },
   {
-    "city": "Detroit",
-    "growth_from_2000_to_2013": "-27.1%",
-    "latitude": 42.331427,
-    "longitude": -83.0457538,
-    "population": "688701",
-    "rank": "18",
-    "state": "Michigan"
-  },
-  {
     "city": "El Paso",
     "growth_from_2000_to_2013": "19.4%",
     "latitude": 31.7775757,
@@ -630,51 +531,6 @@
     "state": "Texas"
   },
   {
-    "city": "Memphis",
-    "growth_from_2000_to_2013": "-5.3%",
-    "latitude": 35.1495343,
-    "longitude": -90.0489801,
-    "population": "653450",
-    "rank": "20",
-    "state": "Tennessee"
-  },
-  {
-    "city": "Seattle",
-    "growth_from_2000_to_2013": "15.6%",
-    "latitude": 47.6062095,
-    "longitude": -122.3320708,
-    "population": "652405",
-    "rank": "21",
-    "state": "Washington"
-  },
-  {
-    "city": "Denver",
-    "growth_from_2000_to_2013": "16.7%",
-    "latitude": 39.7392358,
-    "longitude": -104.990251,
-    "population": "649495",
-    "rank": "22",
-    "state": "Colorado"
-  },
-  {
-    "city": "Washington",
-    "growth_from_2000_to_2013": "13.0%",
-    "latitude": 38.9071923,
-    "longitude": -77.0368707,
-    "population": "646449",
-    "rank": "23",
-    "state": "District of Columbia"
-  },
-  {
-    "city": "Boston",
-    "growth_from_2000_to_2013": "9.4%",
-    "latitude": 42.3600825,
-    "longitude": -71.0588801,
-    "population": "645966",
-    "rank": "24",
-    "state": "Massachusetts"
-  },
-  {
     "city": "Nashville-Davidson",
     "growth_from_2000_to_2013": "16.2%",
     "latitude": 36.1626638,
@@ -682,69 +538,6 @@
     "population": "634464",
     "rank": "25",
     "state": "Tennessee"
-  },
-  {
-    "city": "Baltimore",
-    "growth_from_2000_to_2013": "-4.0%",
-    "latitude": 39.2903848,
-    "longitude": -76.6121893,
-    "population": "622104",
-    "rank": "26",
-    "state": "Maryland"
-  },
-  {
-    "city": "Oklahoma City",
-    "growth_from_2000_to_2013": "20.2%",
-    "latitude": 35.4675602,
-    "longitude": -97.5164276,
-    "population": "610613",
-    "rank": "27",
-    "state": "Oklahoma"
-  },
-  {
-    "city": "Louisville/Jefferson County",
-    "growth_from_2000_to_2013": "10.0%",
-    "latitude": 38.2526647,
-    "longitude": -85.7584557,
-    "population": "609893",
-    "rank": "28",
-    "state": "Kentucky"
-  },
-  {
-    "city": "Portland",
-    "growth_from_2000_to_2013": "15.0%",
-    "latitude": 45.5230622,
-    "longitude": -122.6764816,
-    "population": "609456",
-    "rank": "29",
-    "state": "Oregon"
-  },
-  {
-    "city": "Las Vegas",
-    "growth_from_2000_to_2013": "24.5%",
-    "latitude": 36.1699412,
-    "longitude": -115.1398296,
-    "population": "603488",
-    "rank": "30",
-    "state": "Nevada"
-  },
-  {
-    "city": "Milwaukee",
-    "growth_from_2000_to_2013": "0.3%",
-    "latitude": 43.0389025,
-    "longitude": -87.9064736,
-    "population": "599164",
-    "rank": "31",
-    "state": "Wisconsin"
-  },
-  {
-    "city": "Albuquerque",
-    "growth_from_2000_to_2013": "23.5%",
-    "latitude": 35.0853336,
-    "longitude": -106.6055534,
-    "population": "556495",
-    "rank": "32",
-    "state": "New Mexico"
   },
   {
     "city": "Tucson",
@@ -783,15 +576,6 @@
     "state": "California"
   },
   {
-    "city": "Kansas City",
-    "growth_from_2000_to_2013": "5.5%",
-    "latitude": 39.0997265,
-    "longitude": -94.5785667,
-    "population": "467007",
-    "rank": "37",
-    "state": "Missouri"
-  },
-  {
     "city": "Mesa",
     "growth_from_2000_to_2013": "13.5%",
     "latitude": 33.4151843,
@@ -801,24 +585,6 @@
     "state": "Arizona"
   },
   {
-    "city": "Virginia Beach",
-    "growth_from_2000_to_2013": "5.1%",
-    "latitude": 36.8529263,
-    "longitude": -75.97798499999999,
-    "population": "448479",
-    "rank": "39",
-    "state": "Virginia"
-  },
-  {
-    "city": "Atlanta",
-    "growth_from_2000_to_2013": "6.2%",
-    "latitude": 33.7489954,
-    "longitude": -84.3879824,
-    "population": "447841",
-    "rank": "40",
-    "state": "Georgia"
-  },
-  {
     "city": "Colorado Springs",
     "growth_from_2000_to_2013": "21.4%",
     "latitude": 38.8338816,
@@ -826,15 +592,6 @@
     "population": "439886",
     "rank": "41",
     "state": "Colorado"
-  },
-  {
-    "city": "Omaha",
-    "growth_from_2000_to_2013": "5.9%",
-    "latitude": 41.2523634,
-    "longitude": -95.99798829999999,
-    "population": "434353",
-    "rank": "42",
-    "state": "Nebraska"
   },
   {
     "city": "Raleigh",
@@ -864,15 +621,6 @@
     "state": "California"
   },
   {
-    "city": "Minneapolis",
-    "growth_from_2000_to_2013": "4.5%",
-    "latitude": 44.977753,
-    "longitude": -93.2650108,
-    "population": "400070",
-    "rank": "46",
-    "state": "Minnesota"
-  },
-  {
     "city": "Tulsa",
     "growth_from_2000_to_2013": "1.3%",
     "latitude": 36.1539816,
@@ -891,12 +639,264 @@
     "state": "Ohio"
   },
   {
-    "city": "Wichita",
-    "growth_from_2000_to_2013": "9.7%",
-    "latitude": 37.688889,
-    "longitude": -97.336111,
-    "population": "386552",
-    "rank": "49",
-    "state": "Kansas"
+    "city": "Arlington",
+    "growth_from_2000_to_2013": "13.3%",
+    "latitude": 32.735687,
+    "longitude": -97.10806559999999,
+    "population": "379577",
+    "rank": "50",
+    "state": "Texas"
+  },
+  {
+    "city": "Bakersfield",
+    "growth_from_2000_to_2013": "48.4%",
+    "latitude": 35.3732921,
+    "longitude": -119.0187125,
+    "population": "363630",
+    "rank": "52",
+    "state": "California"
+  },
+  {
+    "city": "Tampa",
+    "growth_from_2000_to_2013": "16.0%",
+    "latitude": 27.950575,
+    "longitude": -82.4571776,
+    "population": "352957",
+    "rank": "53",
+    "state": "Florida"
+  },
+  {
+    "city": "Aurora",
+    "growth_from_2000_to_2013": "24.4%",
+    "latitude": 39.7294319,
+    "longitude": -104.8319195,
+    "population": "345803",
+    "rank": "55",
+    "state": "Colorado"
+  },
+  {
+    "city": "Anaheim",
+    "growth_from_2000_to_2013": "4.7%",
+    "latitude": 33.8352932,
+    "longitude": -117.9145036,
+    "population": "345012",
+    "rank": "56",
+    "state": "California"
+  },
+  {
+    "city": "Santa Ana",
+    "growth_from_2000_to_2013": "-1.2%",
+    "latitude": 33.7455731,
+    "longitude": -117.8678338,
+    "population": "334227",
+    "rank": "57",
+    "state": "California"
+  },
+  {
+    "city": "St. Louis",
+    "growth_from_2000_to_2013": "-8.2%",
+    "latitude": 38.6270025,
+    "longitude": -90.19940419999999,
+    "population": "318416",
+    "rank": "58",
+    "state": "Missouri"
+  },
+  {
+    "city": "Riverside",
+    "growth_from_2000_to_2013": "22.5%",
+    "latitude": 33.9533487,
+    "longitude": -117.3961564,
+    "population": "316619",
+    "rank": "59",
+    "state": "California"
+  },
+  {
+    "city": "Corpus Christi",
+    "growth_from_2000_to_2013": "14.1%",
+    "latitude": 27.8005828,
+    "longitude": -97.39638099999999,
+    "population": "316381",
+    "rank": "60",
+    "state": "Texas"
+  },
+  {
+    "city": "Lexington-Fayette",
+    "growth_from_2000_to_2013": "18.0%",
+    "latitude": 38.0405837,
+    "longitude": -84.5037164,
+    "population": "308428",
+    "rank": "61",
+    "state": "Kentucky"
+  },
+  {
+    "city": "Pittsburgh",
+    "growth_from_2000_to_2013": "-8.3%",
+    "latitude": 40.44062479999999,
+    "longitude": -79.9958864,
+    "population": "305841",
+    "rank": "62",
+    "state": "Pennsylvania"
+  },
+  {
+    "city": "Stockton",
+    "growth_from_2000_to_2013": "21.8%",
+    "latitude": 37.9577016,
+    "longitude": -121.2907796,
+    "population": "298118",
+    "rank": "64",
+    "state": "California"
+  },
+  {
+    "city": "Cincinnati",
+    "growth_from_2000_to_2013": "-10.1%",
+    "latitude": 39.1031182,
+    "longitude": -84.5120196,
+    "population": "297517",
+    "rank": "65",
+    "state": "Ohio"
+  },
+  {
+    "city": "St. Paul",
+    "growth_from_2000_to_2013": "2.8%",
+    "latitude": 44.9537029,
+    "longitude": -93.0899578,
+    "population": "294873",
+    "rank": "66",
+    "state": "Minnesota"
+  },
+  {
+    "city": "Toledo",
+    "growth_from_2000_to_2013": "-10.0%",
+    "latitude": 41.6639383,
+    "longitude": -83.55521200000001,
+    "population": "282313",
+    "rank": "67",
+    "state": "Ohio"
+  },
+  {
+    "city": "Greensboro",
+    "growth_from_2000_to_2013": "22.3%",
+    "latitude": 36.0726354,
+    "longitude": -79.7919754,
+    "population": "279639",
+    "rank": "68",
+    "state": "North Carolina"
+  },
+  {
+    "city": "Plano",
+    "growth_from_2000_to_2013": "22.4%",
+    "latitude": 33.0198431,
+    "longitude": -96.6988856,
+    "population": "274409",
+    "rank": "70",
+    "state": "Texas"
+  },
+  {
+    "city": "Henderson",
+    "growth_from_2000_to_2013": "51.0%",
+    "latitude": 36.0395247,
+    "longitude": -114.9817213,
+    "population": "270811",
+    "rank": "71",
+    "state": "Nevada"
+  },
+  {
+    "city": "Lincoln",
+    "growth_from_2000_to_2013": "18.0%",
+    "latitude": 40.8257625,
+    "longitude": -96.6851982,
+    "population": "268738",
+    "rank": "72",
+    "state": "Nebraska"
+  },
+  {
+    "city": "Buffalo",
+    "growth_from_2000_to_2013": "-11.3%",
+    "latitude": 42.88644679999999,
+    "longitude": -78.8783689,
+    "population": "258959",
+    "rank": "73",
+    "state": "New York"
+  },
+  {
+    "city": "Jersey City",
+    "growth_from_2000_to_2013": "7.2%",
+    "latitude": 40.72815749999999,
+    "longitude": -74.0776417,
+    "population": "257342",
+    "rank": "74",
+    "state": "New Jersey"
+  },
+  {
+    "city": "Chula Vista",
+    "growth_from_2000_to_2013": "46.2%",
+    "latitude": 32.6400541,
+    "longitude": -117.0841955,
+    "population": "256780",
+    "rank": "75",
+    "state": "California"
+  },
+  {
+    "city": "Fort Wayne",
+    "growth_from_2000_to_2013": "1.0%",
+    "latitude": 41.079273,
+    "longitude": -85.1393513,
+    "population": "256496",
+    "rank": "76",
+    "state": "Indiana"
+  },
+  {
+    "city": "Orlando",
+    "growth_from_2000_to_2013": "31.2%",
+    "latitude": 28.5383355,
+    "longitude": -81.3792365,
+    "population": "255483",
+    "rank": "77",
+    "state": "Florida"
+  },
+  {
+    "city": "St. Petersburg",
+    "growth_from_2000_to_2013": "0.3%",
+    "latitude": 27.773056,
+    "longitude": -82.64,
+    "population": "249688",
+    "rank": "78",
+    "state": "Florida"
+  },
+  {
+    "city": "Chandler",
+    "growth_from_2000_to_2013": "38.7%",
+    "latitude": 33.3061605,
+    "longitude": -111.8412502,
+    "population": "249146",
+    "rank": "79",
+    "state": "Arizona"
+  },
+  {
+    "city": "Laredo",
+    "growth_from_2000_to_2013": "38.2%",
+    "latitude": 27.5305671,
+    "longitude": -99.48032409999999,
+    "population": "248142",
+    "rank": "80",
+    "state": "Texas"
+  },
+  {
+    "city": "Norfolk",
+    "growth_from_2000_to_2013": "5.0%",
+    "latitude": 36.8507689,
+    "longitude": -76.28587259999999,
+    "population": "246139",
+    "rank": "81",
+    "state": "Virginia"
+  },
+  {
+    "city": "Durham",
+    "growth_from_2000_to_2013": "29.9%",
+    "latitude": 35.9940329,
+    "longitude": -78.898619,
+    "population": "245475",
+    "rank": "82",
+    "state": "North Carolina"
   }
 ]

--- a/public/assets/pruned_cities.json
+++ b/public/assets/pruned_cities.json
@@ -1,0 +1,902 @@
+[
+  {
+    "city": "New York",
+    "growth_from_2000_to_2013": "4.8%",
+    "latitude": 40.7127837,
+    "longitude": -74.0059413,
+    "population": "8405837",
+    "rank": "1",
+    "state": "New York"
+  },
+  {
+    "city": "Los Angeles",
+    "growth_from_2000_to_2013": "4.8%",
+    "latitude": 34.0522342,
+    "longitude": -118.2436849,
+    "population": "3884307",
+    "rank": "2",
+    "state": "California"
+  },
+  {
+    "city": "Chicago",
+    "growth_from_2000_to_2013": "-6.1%",
+    "latitude": 41.8781136,
+    "longitude": -87.6297982,
+    "population": "2718782",
+    "rank": "3",
+    "state": "Illinois"
+  },
+  {
+    "city": "Houston",
+    "growth_from_2000_to_2013": "11.0%",
+    "latitude": 29.7604267,
+    "longitude": -95.3698028,
+    "population": "2195914",
+    "rank": "4",
+    "state": "Texas"
+  },
+  {
+    "city": "Philadelphia",
+    "growth_from_2000_to_2013": "2.6%",
+    "latitude": 39.9525839,
+    "longitude": -75.1652215,
+    "population": "1553165",
+    "rank": "5",
+    "state": "Pennsylvania"
+  },
+  {
+    "city": "Phoenix",
+    "growth_from_2000_to_2013": "14.0%",
+    "latitude": 33.4483771,
+    "longitude": -112.0740373,
+    "population": "1513367",
+    "rank": "6",
+    "state": "Arizona"
+  },
+  {
+    "city": "Indianapolis",
+    "growth_from_2000_to_2013": "7.8%",
+    "latitude": 39.768403,
+    "longitude": -86.158068,
+    "population": "843393",
+    "rank": "12",
+    "state": "Indiana"
+  },
+  {
+    "city": "Jacksonville",
+    "growth_from_2000_to_2013": "14.3%",
+    "latitude": 30.3321838,
+    "longitude": -81.65565099999999,
+    "population": "842583",
+    "rank": "13",
+    "state": "Florida"
+  },
+  {
+    "city": "Columbus",
+    "growth_from_2000_to_2013": "14.8%",
+    "latitude": 39.9611755,
+    "longitude": -82.99879419999999,
+    "population": "822553",
+    "rank": "15",
+    "state": "Ohio"
+  },
+  {
+    "city": "Charlotte",
+    "growth_from_2000_to_2013": "39.1%",
+    "latitude": 35.2270869,
+    "longitude": -80.8431267,
+    "population": "792862",
+    "rank": "16",
+    "state": "North Carolina"
+  },
+  {
+    "city": "Detroit",
+    "growth_from_2000_to_2013": "-27.1%",
+    "latitude": 42.331427,
+    "longitude": -83.0457538,
+    "population": "688701",
+    "rank": "18",
+    "state": "Michigan"
+  },
+  {
+    "city": "Memphis",
+    "growth_from_2000_to_2013": "-5.3%",
+    "latitude": 35.1495343,
+    "longitude": -90.0489801,
+    "population": "653450",
+    "rank": "20",
+    "state": "Tennessee"
+  },
+  {
+    "city": "Seattle",
+    "growth_from_2000_to_2013": "15.6%",
+    "latitude": 47.6062095,
+    "longitude": -122.3320708,
+    "population": "652405",
+    "rank": "21",
+    "state": "Washington"
+  },
+  {
+    "city": "Denver",
+    "growth_from_2000_to_2013": "16.7%",
+    "latitude": 39.7392358,
+    "longitude": -104.990251,
+    "population": "649495",
+    "rank": "22",
+    "state": "Colorado"
+  },
+  {
+    "city": "Washington",
+    "growth_from_2000_to_2013": "13.0%",
+    "latitude": 38.9071923,
+    "longitude": -77.0368707,
+    "population": "646449",
+    "rank": "23",
+    "state": "District of Columbia"
+  },
+  {
+    "city": "Boston",
+    "growth_from_2000_to_2013": "9.4%",
+    "latitude": 42.3600825,
+    "longitude": -71.0588801,
+    "population": "645966",
+    "rank": "24",
+    "state": "Massachusetts"
+  },
+  {
+    "city": "Baltimore",
+    "growth_from_2000_to_2013": "-4.0%",
+    "latitude": 39.2903848,
+    "longitude": -76.6121893,
+    "population": "622104",
+    "rank": "26",
+    "state": "Maryland"
+  },
+  {
+    "city": "Oklahoma City",
+    "growth_from_2000_to_2013": "20.2%",
+    "latitude": 35.4675602,
+    "longitude": -97.5164276,
+    "population": "610613",
+    "rank": "27",
+    "state": "Oklahoma"
+  },
+  {
+    "city": "Louisville/Jefferson County",
+    "growth_from_2000_to_2013": "10.0%",
+    "latitude": 38.2526647,
+    "longitude": -85.7584557,
+    "population": "609893",
+    "rank": "28",
+    "state": "Kentucky"
+  },
+  {
+    "city": "Portland",
+    "growth_from_2000_to_2013": "15.0%",
+    "latitude": 45.5230622,
+    "longitude": -122.6764816,
+    "population": "609456",
+    "rank": "29",
+    "state": "Oregon"
+  },
+  {
+    "city": "Las Vegas",
+    "growth_from_2000_to_2013": "24.5%",
+    "latitude": 36.1699412,
+    "longitude": -115.1398296,
+    "population": "603488",
+    "rank": "30",
+    "state": "Nevada"
+  },
+  {
+    "city": "Milwaukee",
+    "growth_from_2000_to_2013": "0.3%",
+    "latitude": 43.0389025,
+    "longitude": -87.9064736,
+    "population": "599164",
+    "rank": "31",
+    "state": "Wisconsin"
+  },
+  {
+    "city": "Albuquerque",
+    "growth_from_2000_to_2013": "23.5%",
+    "latitude": 35.0853336,
+    "longitude": -106.6055534,
+    "population": "556495",
+    "rank": "32",
+    "state": "New Mexico"
+  },
+  {
+    "city": "Kansas City",
+    "growth_from_2000_to_2013": "5.5%",
+    "latitude": 39.0997265,
+    "longitude": -94.5785667,
+    "population": "467007",
+    "rank": "37",
+    "state": "Missouri"
+  },
+  {
+    "city": "Virginia Beach",
+    "growth_from_2000_to_2013": "5.1%",
+    "latitude": 36.8529263,
+    "longitude": -75.97798499999999,
+    "population": "448479",
+    "rank": "39",
+    "state": "Virginia"
+  },
+  {
+    "city": "Atlanta",
+    "growth_from_2000_to_2013": "6.2%",
+    "latitude": 33.7489954,
+    "longitude": -84.3879824,
+    "population": "447841",
+    "rank": "40",
+    "state": "Georgia"
+  },
+  {
+    "city": "Omaha",
+    "growth_from_2000_to_2013": "5.9%",
+    "latitude": 41.2523634,
+    "longitude": -95.99798829999999,
+    "population": "434353",
+    "rank": "42",
+    "state": "Nebraska"
+  },
+  {
+    "city": "Minneapolis",
+    "growth_from_2000_to_2013": "4.5%",
+    "latitude": 44.977753,
+    "longitude": -93.2650108,
+    "population": "400070",
+    "rank": "46",
+    "state": "Minnesota"
+  },
+  {
+    "city": "Wichita",
+    "growth_from_2000_to_2013": "9.7%",
+    "latitude": 37.688889,
+    "longitude": -97.336111,
+    "population": "386552",
+    "rank": "49",
+    "state": "Kansas"
+  },
+  {
+    "city": "New Orleans",
+    "growth_from_2000_to_2013": "-21.6%",
+    "latitude": 29.95106579999999,
+    "longitude": -90.0715323,
+    "population": "378715",
+    "rank": "51",
+    "state": "Louisiana"
+  },
+  {
+    "city": "Honolulu",
+    "growth_from_2000_to_2013": "-6.2%",
+    "latitude": 21.3069444,
+    "longitude": -157.8583333,
+    "population": "347884",
+    "rank": "54",
+    "state": "Hawaii"
+  },
+  {
+    "city": "Anchorage",
+    "growth_from_2000_to_2013": "15.4%",
+    "latitude": 61.2180556,
+    "longitude": -149.9002778,
+    "population": "300950",
+    "rank": "63",
+    "state": "Alaska"
+  },
+  {
+    "city": "Newark",
+    "growth_from_2000_to_2013": "2.1%",
+    "latitude": 40.735657,
+    "longitude": -74.1723667,
+    "population": "278427",
+    "rank": "69",
+    "state": "New Jersey"
+  },
+  {
+    "city": "Boise City",
+    "growth_from_2000_to_2013": "9.5%",
+    "latitude": 43.6187102,
+    "longitude": -116.2146068,
+    "population": "214237",
+    "rank": "98",
+    "state": "Idaho"
+  },
+  {
+    "city": "Birmingham",
+    "growth_from_2000_to_2013": "-12.3%",
+    "latitude": 33.5206608,
+    "longitude": -86.80248999999999,
+    "population": "212113",
+    "rank": "101",
+    "state": "Alabama"
+  },
+  {
+    "city": "Des Moines",
+    "growth_from_2000_to_2013": "3.9%",
+    "latitude": 41.6005448,
+    "longitude": -93.6091064,
+    "population": "207510",
+    "rank": "104",
+    "state": "Iowa"
+  },
+  {
+    "city": "Little Rock",
+    "growth_from_2000_to_2013": "7.6%",
+    "latitude": 34.7464809,
+    "longitude": -92.28959479999999,
+    "population": "197357",
+    "rank": "118",
+    "state": "Arkansas"
+  },
+  {
+    "city": "Salt Lake City",
+    "growth_from_2000_to_2013": "5.1%",
+    "latitude": 40.7607793,
+    "longitude": -111.8910474,
+    "population": "191180",
+    "rank": "124",
+    "state": "Utah"
+  },
+  {
+    "city": "Providence",
+    "growth_from_2000_to_2013": "2.3%",
+    "latitude": 41.8239891,
+    "longitude": -71.4128343,
+    "population": "177994",
+    "rank": "134",
+    "state": "Rhode Island"
+  },
+  {
+    "city": "Jackson",
+    "growth_from_2000_to_2013": "-6.8%",
+    "latitude": 32.2987573,
+    "longitude": -90.1848103,
+    "population": "172638",
+    "rank": "138",
+    "state": "Mississippi"
+  },
+  {
+    "city": "Sioux Falls",
+    "growth_from_2000_to_2013": "31.1%",
+    "latitude": 43.5445959,
+    "longitude": -96.73110340000001,
+    "population": "164676",
+    "rank": "147",
+    "state": "South Dakota"
+  },
+  {
+    "city": "Bridgeport",
+    "growth_from_2000_to_2013": "5.4%",
+    "latitude": 41.1865478,
+    "longitude": -73.19517669999999,
+    "population": "147216",
+    "rank": "172",
+    "state": "Connecticut"
+  },
+  {
+    "city": "Columbia",
+    "growth_from_2000_to_2013": "11.7%",
+    "latitude": 34.0007104,
+    "longitude": -81.0348144,
+    "population": "133358",
+    "rank": "192",
+    "state": "South Carolina"
+  },
+  {
+    "city": "Fargo",
+    "growth_from_2000_to_2013": "24.9%",
+    "latitude": 46.8771863,
+    "longitude": -96.7898034,
+    "population": "113658",
+    "rank": "237",
+    "state": "North Dakota"
+  },
+  {
+    "city": "Manchester",
+    "growth_from_2000_to_2013": "2.9%",
+    "latitude": 42.9956397,
+    "longitude": -71.4547891,
+    "population": "110378",
+    "rank": "248",
+    "state": "New Hampshire"
+  },
+  {
+    "city": "Billings",
+    "growth_from_2000_to_2013": "18.6%",
+    "latitude": 45.7832856,
+    "longitude": -108.5006904,
+    "population": "109059",
+    "rank": "256",
+    "state": "Montana"
+  },
+  {
+    "city": "Wilmington",
+    "growth_from_2000_to_2013": "-1.6%",
+    "latitude": 39.7390721,
+    "longitude": -75.5397878,
+    "population": "71525",
+    "rank": "470",
+    "state": "Delaware"
+  },
+  {
+    "city": "Portland",
+    "growth_from_2000_to_2013": "3.2%",
+    "latitude": 43.66147100000001,
+    "longitude": -70.2553259,
+    "population": "66318",
+    "rank": "519",
+    "state": "Maine"
+  },
+  {
+    "city": "Cheyenne",
+    "growth_from_2000_to_2013": "16.9%",
+    "latitude": 41.1399814,
+    "longitude": -104.8202462,
+    "population": "62448",
+    "rank": "558",
+    "state": "Wyoming"
+  },
+  {
+    "city": "Charleston",
+    "growth_from_2000_to_2013": "-4.7%",
+    "latitude": 38.3498195,
+    "longitude": -81.6326234,
+    "population": "50821",
+    "rank": "725",
+    "state": "West Virginia"
+  },
+  {
+    "city": "Burlington",
+    "growth_from_2000_to_2013": "6.1%",
+    "latitude": 44.4758825,
+    "longitude": -73.21207199999999,
+    "population": "42284",
+    "rank": "870",
+    "state": "Vermont"
+  },
+  {
+    "city": "New York",
+    "growth_from_2000_to_2013": "4.8%",
+    "latitude": 40.7127837,
+    "longitude": -74.0059413,
+    "population": "8405837",
+    "rank": "1",
+    "state": "New York"
+  },
+  {
+    "city": "Los Angeles",
+    "growth_from_2000_to_2013": "4.8%",
+    "latitude": 34.0522342,
+    "longitude": -118.2436849,
+    "population": "3884307",
+    "rank": "2",
+    "state": "California"
+  },
+  {
+    "city": "Chicago",
+    "growth_from_2000_to_2013": "-6.1%",
+    "latitude": 41.8781136,
+    "longitude": -87.6297982,
+    "population": "2718782",
+    "rank": "3",
+    "state": "Illinois"
+  },
+  {
+    "city": "Houston",
+    "growth_from_2000_to_2013": "11.0%",
+    "latitude": 29.7604267,
+    "longitude": -95.3698028,
+    "population": "2195914",
+    "rank": "4",
+    "state": "Texas"
+  },
+  {
+    "city": "Philadelphia",
+    "growth_from_2000_to_2013": "2.6%",
+    "latitude": 39.9525839,
+    "longitude": -75.1652215,
+    "population": "1553165",
+    "rank": "5",
+    "state": "Pennsylvania"
+  },
+  {
+    "city": "Phoenix",
+    "growth_from_2000_to_2013": "14.0%",
+    "latitude": 33.4483771,
+    "longitude": -112.0740373,
+    "population": "1513367",
+    "rank": "6",
+    "state": "Arizona"
+  },
+  {
+    "city": "San Antonio",
+    "growth_from_2000_to_2013": "21.0%",
+    "latitude": 29.4241219,
+    "longitude": -98.49362819999999,
+    "population": "1409019",
+    "rank": "7",
+    "state": "Texas"
+  },
+  {
+    "city": "San Diego",
+    "growth_from_2000_to_2013": "10.5%",
+    "latitude": 32.715738,
+    "longitude": -117.1610838,
+    "population": "1355896",
+    "rank": "8",
+    "state": "California"
+  },
+  {
+    "city": "Dallas",
+    "growth_from_2000_to_2013": "5.6%",
+    "latitude": 32.7766642,
+    "longitude": -96.79698789999999,
+    "population": "1257676",
+    "rank": "9",
+    "state": "Texas"
+  },
+  {
+    "city": "San Jose",
+    "growth_from_2000_to_2013": "10.5%",
+    "latitude": 37.3382082,
+    "longitude": -121.8863286,
+    "population": "998537",
+    "rank": "10",
+    "state": "California"
+  },
+  {
+    "city": "Austin",
+    "growth_from_2000_to_2013": "31.7%",
+    "latitude": 30.267153,
+    "longitude": -97.7430608,
+    "population": "885400",
+    "rank": "11",
+    "state": "Texas"
+  },
+  {
+    "city": "Indianapolis",
+    "growth_from_2000_to_2013": "7.8%",
+    "latitude": 39.768403,
+    "longitude": -86.158068,
+    "population": "843393",
+    "rank": "12",
+    "state": "Indiana"
+  },
+  {
+    "city": "Jacksonville",
+    "growth_from_2000_to_2013": "14.3%",
+    "latitude": 30.3321838,
+    "longitude": -81.65565099999999,
+    "population": "842583",
+    "rank": "13",
+    "state": "Florida"
+  },
+  {
+    "city": "San Francisco",
+    "growth_from_2000_to_2013": "7.7%",
+    "latitude": 37.7749295,
+    "longitude": -122.4194155,
+    "population": "837442",
+    "rank": "14",
+    "state": "California"
+  },
+  {
+    "city": "Columbus",
+    "growth_from_2000_to_2013": "14.8%",
+    "latitude": 39.9611755,
+    "longitude": -82.99879419999999,
+    "population": "822553",
+    "rank": "15",
+    "state": "Ohio"
+  },
+  {
+    "city": "Charlotte",
+    "growth_from_2000_to_2013": "39.1%",
+    "latitude": 35.2270869,
+    "longitude": -80.8431267,
+    "population": "792862",
+    "rank": "16",
+    "state": "North Carolina"
+  },
+  {
+    "city": "Fort Worth",
+    "growth_from_2000_to_2013": "45.1%",
+    "latitude": 32.7554883,
+    "longitude": -97.3307658,
+    "population": "792727",
+    "rank": "17",
+    "state": "Texas"
+  },
+  {
+    "city": "Detroit",
+    "growth_from_2000_to_2013": "-27.1%",
+    "latitude": 42.331427,
+    "longitude": -83.0457538,
+    "population": "688701",
+    "rank": "18",
+    "state": "Michigan"
+  },
+  {
+    "city": "El Paso",
+    "growth_from_2000_to_2013": "19.4%",
+    "latitude": 31.7775757,
+    "longitude": -106.4424559,
+    "population": "674433",
+    "rank": "19",
+    "state": "Texas"
+  },
+  {
+    "city": "Memphis",
+    "growth_from_2000_to_2013": "-5.3%",
+    "latitude": 35.1495343,
+    "longitude": -90.0489801,
+    "population": "653450",
+    "rank": "20",
+    "state": "Tennessee"
+  },
+  {
+    "city": "Seattle",
+    "growth_from_2000_to_2013": "15.6%",
+    "latitude": 47.6062095,
+    "longitude": -122.3320708,
+    "population": "652405",
+    "rank": "21",
+    "state": "Washington"
+  },
+  {
+    "city": "Denver",
+    "growth_from_2000_to_2013": "16.7%",
+    "latitude": 39.7392358,
+    "longitude": -104.990251,
+    "population": "649495",
+    "rank": "22",
+    "state": "Colorado"
+  },
+  {
+    "city": "Washington",
+    "growth_from_2000_to_2013": "13.0%",
+    "latitude": 38.9071923,
+    "longitude": -77.0368707,
+    "population": "646449",
+    "rank": "23",
+    "state": "District of Columbia"
+  },
+  {
+    "city": "Boston",
+    "growth_from_2000_to_2013": "9.4%",
+    "latitude": 42.3600825,
+    "longitude": -71.0588801,
+    "population": "645966",
+    "rank": "24",
+    "state": "Massachusetts"
+  },
+  {
+    "city": "Nashville-Davidson",
+    "growth_from_2000_to_2013": "16.2%",
+    "latitude": 36.1626638,
+    "longitude": -86.7816016,
+    "population": "634464",
+    "rank": "25",
+    "state": "Tennessee"
+  },
+  {
+    "city": "Baltimore",
+    "growth_from_2000_to_2013": "-4.0%",
+    "latitude": 39.2903848,
+    "longitude": -76.6121893,
+    "population": "622104",
+    "rank": "26",
+    "state": "Maryland"
+  },
+  {
+    "city": "Oklahoma City",
+    "growth_from_2000_to_2013": "20.2%",
+    "latitude": 35.4675602,
+    "longitude": -97.5164276,
+    "population": "610613",
+    "rank": "27",
+    "state": "Oklahoma"
+  },
+  {
+    "city": "Louisville/Jefferson County",
+    "growth_from_2000_to_2013": "10.0%",
+    "latitude": 38.2526647,
+    "longitude": -85.7584557,
+    "population": "609893",
+    "rank": "28",
+    "state": "Kentucky"
+  },
+  {
+    "city": "Portland",
+    "growth_from_2000_to_2013": "15.0%",
+    "latitude": 45.5230622,
+    "longitude": -122.6764816,
+    "population": "609456",
+    "rank": "29",
+    "state": "Oregon"
+  },
+  {
+    "city": "Las Vegas",
+    "growth_from_2000_to_2013": "24.5%",
+    "latitude": 36.1699412,
+    "longitude": -115.1398296,
+    "population": "603488",
+    "rank": "30",
+    "state": "Nevada"
+  },
+  {
+    "city": "Milwaukee",
+    "growth_from_2000_to_2013": "0.3%",
+    "latitude": 43.0389025,
+    "longitude": -87.9064736,
+    "population": "599164",
+    "rank": "31",
+    "state": "Wisconsin"
+  },
+  {
+    "city": "Albuquerque",
+    "growth_from_2000_to_2013": "23.5%",
+    "latitude": 35.0853336,
+    "longitude": -106.6055534,
+    "population": "556495",
+    "rank": "32",
+    "state": "New Mexico"
+  },
+  {
+    "city": "Tucson",
+    "growth_from_2000_to_2013": "7.5%",
+    "latitude": 32.2217429,
+    "longitude": -110.926479,
+    "population": "526116",
+    "rank": "33",
+    "state": "Arizona"
+  },
+  {
+    "city": "Fresno",
+    "growth_from_2000_to_2013": "18.3%",
+    "latitude": 36.7468422,
+    "longitude": -119.7725868,
+    "population": "509924",
+    "rank": "34",
+    "state": "California"
+  },
+  {
+    "city": "Sacramento",
+    "growth_from_2000_to_2013": "17.2%",
+    "latitude": 38.5815719,
+    "longitude": -121.4943996,
+    "population": "479686",
+    "rank": "35",
+    "state": "California"
+  },
+  {
+    "city": "Long Beach",
+    "growth_from_2000_to_2013": "1.5%",
+    "latitude": 33.7700504,
+    "longitude": -118.1937395,
+    "population": "469428",
+    "rank": "36",
+    "state": "California"
+  },
+  {
+    "city": "Kansas City",
+    "growth_from_2000_to_2013": "5.5%",
+    "latitude": 39.0997265,
+    "longitude": -94.5785667,
+    "population": "467007",
+    "rank": "37",
+    "state": "Missouri"
+  },
+  {
+    "city": "Mesa",
+    "growth_from_2000_to_2013": "13.5%",
+    "latitude": 33.4151843,
+    "longitude": -111.8314724,
+    "population": "457587",
+    "rank": "38",
+    "state": "Arizona"
+  },
+  {
+    "city": "Virginia Beach",
+    "growth_from_2000_to_2013": "5.1%",
+    "latitude": 36.8529263,
+    "longitude": -75.97798499999999,
+    "population": "448479",
+    "rank": "39",
+    "state": "Virginia"
+  },
+  {
+    "city": "Atlanta",
+    "growth_from_2000_to_2013": "6.2%",
+    "latitude": 33.7489954,
+    "longitude": -84.3879824,
+    "population": "447841",
+    "rank": "40",
+    "state": "Georgia"
+  },
+  {
+    "city": "Colorado Springs",
+    "growth_from_2000_to_2013": "21.4%",
+    "latitude": 38.8338816,
+    "longitude": -104.8213634,
+    "population": "439886",
+    "rank": "41",
+    "state": "Colorado"
+  },
+  {
+    "city": "Omaha",
+    "growth_from_2000_to_2013": "5.9%",
+    "latitude": 41.2523634,
+    "longitude": -95.99798829999999,
+    "population": "434353",
+    "rank": "42",
+    "state": "Nebraska"
+  },
+  {
+    "city": "Raleigh",
+    "growth_from_2000_to_2013": "48.7%",
+    "latitude": 35.7795897,
+    "longitude": -78.6381787,
+    "population": "431746",
+    "rank": "43",
+    "state": "North Carolina"
+  },
+  {
+    "city": "Miami",
+    "growth_from_2000_to_2013": "14.9%",
+    "latitude": 25.7616798,
+    "longitude": -80.1917902,
+    "population": "417650",
+    "rank": "44",
+    "state": "Florida"
+  },
+  {
+    "city": "Oakland",
+    "growth_from_2000_to_2013": "1.3%",
+    "latitude": 37.8043637,
+    "longitude": -122.2711137,
+    "population": "406253",
+    "rank": "45",
+    "state": "California"
+  },
+  {
+    "city": "Minneapolis",
+    "growth_from_2000_to_2013": "4.5%",
+    "latitude": 44.977753,
+    "longitude": -93.2650108,
+    "population": "400070",
+    "rank": "46",
+    "state": "Minnesota"
+  },
+  {
+    "city": "Tulsa",
+    "growth_from_2000_to_2013": "1.3%",
+    "latitude": 36.1539816,
+    "longitude": -95.99277500000001,
+    "population": "398121",
+    "rank": "47",
+    "state": "Oklahoma"
+  },
+  {
+    "city": "Cleveland",
+    "growth_from_2000_to_2013": "-18.1%",
+    "latitude": 41.49932,
+    "longitude": -81.6943605,
+    "population": "390113",
+    "rank": "48",
+    "state": "Ohio"
+  },
+  {
+    "city": "Wichita",
+    "growth_from_2000_to_2013": "9.7%",
+    "latitude": 37.688889,
+    "longitude": -97.336111,
+    "population": "386552",
+    "rank": "49",
+    "state": "Kansas"
+  }
+]

--- a/public/javascripts/form.js
+++ b/public/javascripts/form.js
@@ -5,21 +5,21 @@ $(function () {
   cities = $.ajax({
     type: "GET",
     url: "../cities.json",
-    async: false
+    async: false,
   }).responseJSON;
 });
 
 // Filter cities matching state input and populate city dropdown
 $(function () {
   $("#state_select").change(function () {
-    const in_state = cities.filter(data =>
+    const in_state = cities.filter((data) =>
       data.state.match($("#state_select").val())
     );
     $("#city_select").empty();
     $("#city_select").append(
       '<option value="" selected disabled>City</option>'
     );
-    in_state.forEach(element => {
+    in_state.forEach((element) => {
       $("#city_select").append(
         `<option value="${element.city}">${element.city}</option>`
       );
@@ -32,7 +32,7 @@ $(function () {
 $(function () {
   $("#city_select").change(function () {
     const city = cities.find(
-      data =>
+      (data) =>
         data.state.match($("#state_select").val()) &&
         data.city.match($("#city_select").val())
     );

--- a/public/javascripts/form.js
+++ b/public/javascripts/form.js
@@ -4,7 +4,7 @@ var cities;
 $(function () {
   cities = $.ajax({
     type: "GET",
-    url: "../cities.json",
+    url: "../cities",
     async: false,
   }).responseJSON;
 });

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,14 +6,14 @@ var cities = require("../public/assets/cities");
 /* GET home page. */
 router.get("/", function (req, res, next) {
   res.render("index", {
-    title: "TWITTER MOOD"
+    title: "TWITTER MOOD",
   });
 });
 
 router.post("/mood", function (req, res) {
   mood
     .get_tweets_and_sentiment(req.body.coords, req.body.radius)
-    .then(tweets => {
+    .then((tweets) => {
       res.render("tweets", { title: "TWITTER MOOD", tweets: tweets });
     })
     .catch(); //TODO: Error handling

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,7 @@
 var express = require("express");
 var router = express.Router();
 var mood = require("../backend/city_tweet_mood");
-var cities = require("../public/assets/cities");
+var cities = require("../public/assets/pruned_cities");
 
 /* GET home page. */
 router.get("/", function (req, res, next) {
@@ -19,7 +19,7 @@ router.post("/mood", function (req, res) {
     .catch(); //TODO: Error handling
 });
 
-router.get("/cities.json", function (req, res) {
+router.get("/cities", function (req, res) {
   res.header("Content-Type", "application/json");
   res.send(JSON.stringify(cities));
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -34,7 +34,6 @@
               <option value="District of Columbia">District of Columbia</option>
               <option value="Florida">Florida</option>
               <option value="Georgia">Georgia</option>
-              <option value="Guam">Guam</option>
               <option value="Hawaii">Hawaii</option>
               <option value="Idaho">Idaho</option>
               <option value="Illinois">Illinois</option>
@@ -59,12 +58,10 @@
               <option value="New York">New York</option>
               <option value="North Carolina">North Carolina</option>
               <option value="North Dakota">North Dakota</option>
-              <option value="Northern Marianas Islands">Northern Marianas Islands</option>
               <option value="Ohio">Ohio</option>
               <option value="Oklahoma">Oklahoma</option>
               <option value="Oregon">Oregon</option>
               <option value="Pennsylvania">Pennsylvania</option>
-              <option value="Puerto Rico">Puerto Rico</option>
               <option value="Rhode Island">Rhode Island</option>
               <option value="South Carolina">South Carolina</option>
               <option value="South Dakota">South Dakota</option>


### PR DESCRIPTION
created a pruned cities list so that now we have the most populous city for each state, as well as the 50 most populous cities in the USA that aren't already on that list.  Also nixed Guam and Puerto Rico